### PR TITLE
WIP: Update test organization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - run: docker run --rm -tv $(pwd):/src -w /src ghdl/vunit:llvm python3 run.py
+    - run: docker run --rm -tv $(pwd):/src -w /src ghdl/vunit:llvm python3 run.py -v
 #    - uses: actions/upload-artifact@master
 #      with:
 #        name: <name of the resulting zipfile

--- a/run.py
+++ b/run.py
@@ -17,9 +17,12 @@ if "keep_going" in args:
     args.keep_going = True
 
 ui = VUnit.from_args(args, vhdl_standard=vhdl_standard)
+
 vhdl_2008 = ui.add_library("vhdl_2008")
+vhdl_2008_basic = ui.add_library("vhdl_2008_basic")
 vhdl_2019 = ui.add_library("vhdl_2019")
 vhdl_2008.add_source_files(join(root, "vhdl_2008", "*.vhd"))
+vhdl_2008_basic.add_source_files(join(root, "vhdl_2008", "basic", "*.vhd"))
 vhdl_2019.add_source_files(join(root, "vhdl_2019", "*.vhd"))
 
 if "keep_going" in args:

--- a/run_support.py
+++ b/run_support.py
@@ -23,6 +23,7 @@ def run_with_compile_errors(ui, args, vhdl_standard):
     n_tests = 0
     testbenches = (
         ui.library("vhdl_2008").get_test_benches()
+        + ui.library("vhdl_2008_basic").get_test_benches()
         + ui.library("vhdl_2019").get_test_benches()
     )
     total_start_time = ostools.get_time()
@@ -42,9 +43,12 @@ def run_with_compile_errors(ui, args, vhdl_standard):
             n_tests += 1
             args.test_patterns = [full_test_name]
             ui = VUnit.from_args(args, vhdl_standard=vhdl_standard)
+            ui.enable_location_preprocessing()
             vhdl_2008 = ui.add_library("vhdl_2008")
+            vhdl_2008_basic = ui.add_library("vhdl_2008_basic")
             vhdl_2019 = ui.add_library("vhdl_2019")
             vhdl_2008.add_source_files(join(root, "vhdl_2008", "*.vhd"))
+            vhdl_2008_basic.add_source_files(join(root, "vhdl_2008", "basic", "*.vhd"))
             vhdl_2019.add_source_files(join(root, "vhdl_2019", "*.vhd"))
 
             try:

--- a/vhdl_2008/basic/tb_bit_string_literals.vhd
+++ b/vhdl_2008/basic/tb_bit_string_literals.vhd
@@ -17,14 +17,17 @@ begin
       variable value : std_logic_vector(5 downto 0) := "000000";
    begin
       test_runner_setup(runner, runner_cfg);
+      show(display_handler, pass);
 
       while test_suite loop
-         if run("Literal downsize as hex width") then
+         if run("Test downsizing of hexadecimal literal") then
+            -- vunit: .LRM-2008_15_8
             value := 6x"0f";
-            check_equal(value, std_logic_vector'("001111"));
-         elsif run("Literal upsize as hex width") then
+            check_equal(value, std_logic_vector'("001111"), result("for 6x""0f"""));
+         elsif run("Test upsizing of hexadecimal literal") then
+            -- vunit: .LRM-2008_15_8
             value := 6x"5";
-            check_equal(value, std_logic_vector'("000101"));
+            check_equal(value, std_logic_vector'("000100"), result("for 6x""4""")); -- Fake a bug
          elsif run("Literal hex signed value extension") then
             value := 6Sx"a";
             check_equal(value, std_logic_vector'("111010"));


### PR DESCRIPTION
This is work towards a clearer organisations as discussed in #4. The following changes have been evaluated

1. Added a new level of directories under the standard version directory. So far a `basic` directory has been added with the intention to contain tests evaluating basic support of features.
2. The new levels are complied into their own libraries, for example `vhdl_2008_basic`. This means that tests can be filtered based on language version and level
3. Examples of improved reporting and use of attributes to reference the LRM have been added, for example

``` vhdl
         if run("Test downsizing of hexadecimal literal") then
            -- vunit: .LRM-2008_15_8
            value := 6x"0f";
            check_equal(value, std_logic_vector'("001111"), result("for 6x""0f"""));
         elsif run("Test upsizing of hexadecimal literal") then
            -- vunit: .LRM-2008_15_8
            value := 6x"5";
            check_equal(value, std_logic_vector'("000100"), result("for 6x""4""")); -- Fake a bug
```
4. Location preprocessing has been added to trace errors to file/line and pass messages have been enable. See examples [here](https://github.com/VHDL/Compliance-Tests/pull/6/checks?check_run_id=262944654#step:3:1948) and [here](https://github.com/VHDL/Compliance-Tests/pull/6/checks?check_run_id=262944654#step:3:1928)