### PR TITLE
ci: do not run tests in parallel

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -27,7 +27,7 @@ jobs:
 
       - run: |
           python -m pip install -r requirements.txt
-          python run.py -k -v -p10
+          python run.py -k -v
 
 
   CoSim:


### PR DESCRIPTION
Running tests in parallel makes it difficult to read the logs in order to find why a test failed. I think we should run the tests in CI using a single thread, so that the log is ordered.