### PR TITLE
run: use GITHUB_STEP_SUMMARY when running within GitHub Actions

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -25,9 +25,9 @@ jobs:
         with:
           python-version: 3.9
 
-      - run: |
-          python -m pip install -r requirements.txt
-          python run.py -k -v
+      - run: python -m pip install -r requirements.txt
+
+      - run: python run.py -k -v
 
 
   CoSim:

--- a/run.py
+++ b/run.py
@@ -1,7 +1,33 @@
 #!/usr/bin/env python3
 
+from os import environ
 from pathlib import Path
 from vunit import VUnit
+
+
+# CI utilities
+
+isGHA: bool = "GITHUB_ACTIONS" in environ
+
+def GHASummary(content: str):
+    if not isGHA:
+        print("· Printing GHA summary skipped")
+        return
+    with open(Path(environ["GITHUB_STEP_SUMMARY"]), "a") as wfptr:
+        wfptr.write(content)
+
+def post_func(results):
+    report = results.get_report()
+    GHASummary(f'''\
+Output path: {report.output_path!s}
+Failed tests:
+''')
+    for key, test in report.tests.items():
+        if test.status == 'failed':
+            GHASummary(f'- {key!s}\n')
+
+#---
+
 
 root = Path(__file__).resolve().parent
 
@@ -33,6 +59,6 @@ ui.set_compile_option("activehdl.vcom_flags", ["-dbg"])
 
 # Mark a test run as successful even if failing tests are found.
 try:
-    ui.main()
+    ui.main(post_run=post_func)
 except SystemExit:
     pass


### PR DESCRIPTION
Close #16.

This PR prints the list of failed tests to the GITHUB_STEP_SUMMARY (https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/), so that we don't need to open the logs in order to see that.

Results are obtained through the `post_func` feature of VUnit.