### PR TITLE
ci: run tests with ghdl (mcode), ghdl/llvm and nvc; using containers from hdl/containers

### DIFF
--- a/.github/run.sh
+++ b/.github/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -e
+
+cd $(dirname "$0")/..
+
+apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+  python3-pip
+
+python3 -m pip install -r requirements.txt
+
+python3 run.py -k -v

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -12,22 +12,29 @@ jobs:
 
   Compliance:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tool:
+          - ghdl
+          - ghdl/llvm
+          - nvc
 
     steps:
 
       - uses: actions/checkout@v3
 
-      - uses: ghdl/setup-ghdl-ci@master
-        with:
-          backend: gcc
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-
-      - run: python -m pip install -r requirements.txt
-
-      - run: python run.py -k -v
+      # Cannot use 'docker://' syntax here because using variables (e.g matrix.tool) is not supported.
+      # See https://github.com/orgs/community/discussions/9049.
+      # Therefore, we need to call docker explicitly.
+      - run: >-
+          docker run --rm -t
+          -v $(pwd):/wrk -w /wrk
+          -v $GITHUB_STEP_SUMMARY:/wrk/GHSS
+          -e GITHUB_STEP_SUMMARY=/wrk/GHSS
+          -e GITHUB_ACTIONS
+          gcr.io/hdl-containers/${{ matrix.tool }}
+          ./.github/run.sh
 
 
   CoSim:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-vunit-hdl @ git+https://github.com/VUnit/vunit.git@v5.0.0
+https://github.com/VUnit/vunit/archive/v5.0.0.zip#vunit-hdl


### PR DESCRIPTION
This PR adds a matrix to job Compliance, in order to run three jobs in parallel.

Instead of installing the tools on the host, containers from [hdl/containers](https://github.com/hdl/containers) are used.