### PR TITLE
Update vhdl_2019/tb_043 to avoid VUnit race conditions.

### DIFF
--- a/run.py
+++ b/run.py
@@ -26,7 +26,7 @@ Failed tests:
         if test.status == 'failed':
             GHASummary(f'- {key!s}\n')
 
-#---
+# ---
 
 
 root = Path(__file__).resolve().parent
@@ -56,6 +56,10 @@ for std in ["2008", "2019"]:
 # unless the code is compiled with the debug option.
 ui.set_compile_option("rivierapro.vcom_flags", ["-dbg"])
 ui.set_compile_option("activehdl.vcom_flags", ["-dbg"])
+
+# Prevent PSL errors from failing the simulation but allow the VHDL assertion verifying the
+# PSL functionality to fail with severity failure
+ui.library("vhdl_2019").test_bench("tb_api_and_attributes_for_psl").set_sim_option("vhdl_assert_stop_level", "failure")
 
 # Mark a test run as successful even if failing tests are found.
 try:

--- a/vhdl_2019/tb_043.vhd
+++ b/vhdl_2019/tb_043.vhd
@@ -2,32 +2,25 @@
 -- https://www.eda-twiki.org/cgi-bin/view.cgi/P1076/LCS2016_043
 -- 1076-2019 sections: 16.2.7 (PSL attributes) and 16.5.8 (PSL API)
 
+library vunit_lib;
+context vunit_lib.vunit_context;
+
 library ieee;
 use ieee.std_logic_1164.all;
 
 use std.env.all;
 
-entity e011 is
-end entity ;
+entity tb_api_and_attributes_for_psl is
+  generic(runner_cfg : string);
+end entity;
 
-architecture arch of e011 is
-
+architecture tb of tb_api_and_attributes_for_psl is
   signal clk, req, grant : std_logic := '0';
   signal rst : std_logic := '1';
 
   default clock is rising_edge(clk);
-
 begin
-
   clk <= not clk after 5 ns;
-
-  reset : process is
-  begin
-    wait until rising_edge(clk);
-    wait until rising_edge(clk);
-    rst <= '0';
-    wait;
-  end process;
 
   stimuli : process is
   begin
@@ -45,7 +38,6 @@ begin
     wait;
   end process;
 
-  -- PSL definitions & directives
   property req_grant_prop is always (req -> next(grant));
   sequence req_grant_seq is {req; grant};
   req_grant_assert : assert req_grant_prop;
@@ -53,75 +45,62 @@ begin
   req_grant_assume : assume req_grant_prop;
   rst_restrict : restrict {rst[*3]; not rst}[+];
 
-  -- PSL attributes tests (1076-2019 16.2.7)
-  pslattributes : process is
-  begin
-    wait until rising_edge(clk) and rst = '0';
-    wait until rising_edge(clk);
-    assert not rst_restrict'signal severity failure;
-    -- Occurance of req -> next grant
-    wait until req_grant_prop'event;
-    -- Test p'event atributes
-    assert req_grant_seq'event severity failure;
-    assert req_grant_assert'event severity failure;
-    assert req_grant_cover'event severity failure;
-    -- Test p'signal attributes
-    assert req_grant_assert'signal severity failure;
-    assert req_grant_cover'signal severity failure;
-    assert req_grant_assume'signal severity failure;
-    -- Occurance of req -> next not grant
-    wait until rising_edge(clk) and req = '1';
-    wait until rising_edge(clk);
-    assert not req_grant_assert'signal severity failure;
-    assert not req_grant_assume'signal severity failure;
-    wait;
-  end process;
-
-  -- PSL API tests (1076-2019 16.5.8)
-  pslapi : process is
-  begin
-    -- Test return values after elaboration
-    assert not PslAssertFailed severity failure;
-    assert not PslIsCovered severity failure;
-    assert not PslIsAssertCovered severity failure;
-    -- Enable coverage of asserts
-    SetPslCoverAssert;
-    assert GetPslCoverAssert severity failure;
-    -- Occurance of req -> next grant
-    wait until rising_edge(clk) and grant = '1';
-    assert not PslAssertFailed severity failure;
-    assert PslIsCovered severity failure;
-    assert PslIsAssertCovered severity failure;
-    -- Occurance of req -> next not grant
-    wait until rising_edge(clk) and req = '1';
-    wait until rising_edge(clk);
-    assert PslAssertFailed severity failure;
-    -- Clear internal PSL state information
-    ClearPslState;
-    assert not PslAssertFailed severity failure;
-    assert not PslIsCovered severity failure;
-    assert not PslIsAssertCovered severity failure;
-    wait;
-  end process;
-
-end architecture arch;
-
---
-
-library vunit_lib;
-context vunit_lib.vunit_context;
-
-entity tb_api_and_attributes_for_psl is
-  generic ( runner_cfg : string );
-end entity;
-
-architecture tb of tb_api_and_attributes_for_psl is
-begin
-  U_e011 : entity work.e011;
   test_runner: process is
+    variable test : boolean;
   begin
     test_runner_setup(runner, runner_cfg);
-    info("LCS-2016-043: API and Attributes for PSL");
+
+    while test_suite loop
+      wait until rising_edge(clk);
+      wait until rising_edge(clk);
+      rst <= '0';
+
+      if run("PSL attributes tests (1076-2019 16.2.7)") then
+        wait until rising_edge(clk) and rst = '0';
+        wait until rising_edge(clk);
+        assert not rst_restrict'signal severity failure;
+        -- Occurance of req -> next grant
+        wait until req_grant_prop'event;
+        -- Test p'event attributes
+        assert req_grant_seq'event severity failure;
+        assert req_grant_assert'event severity failure;
+        assert req_grant_cover'event severity failure;
+        -- Test p'signal attributes
+        assert req_grant_assert'signal severity failure;
+        assert req_grant_cover'signal severity failure;
+        assert req_grant_assume'signal severity failure;
+        -- Occurance of req -> next not grant
+        wait until rising_edge(clk) and req = '1';
+        wait until rising_edge(clk);
+        assert not req_grant_assert'signal severity failure;
+        assert not req_grant_assume'signal severity failure;
+
+      elsif run("PSL API tests (1076-2019 16.5.8)") then
+        -- Test return values after elaboration
+        assert not PslAssertFailed severity failure;
+        assert not PslIsCovered severity failure;
+        assert not PslIsAssertCovered severity failure;
+        -- Enable coverage of asserts
+        SetPslCoverAssert;
+        assert GetPslCoverAssert;
+        -- Occurance of req -> next grant
+        wait until rising_edge(clk) and grant = '1';
+        assert not PslAssertFailed severity failure;
+        assert PslIsCovered severity failure;
+        assert PslIsAssertCovered severity failure;
+        -- Occurance of req -> next not grant
+        wait until rising_edge(clk) and req = '1';
+        wait until rising_edge(clk);
+        assert PslAssertFailed severity failure;
+        -- Clear internal PSL state information
+        ClearPslState;
+        assert not PslAssertFailed severity failure;
+        assert not PslIsCovered severity failure;
+        assert not PslIsAssertCovered severity failure;
+
+      end if;
+    end loop;
+
     test_runner_cleanup(runner);
     wait;
   end process test_runner;


### PR DESCRIPTION
tb_043 suffers from the race discussion previously discussed here: https://github.com/VHDL/Compliance-Tests/pull/13#discussion_r1125132270

I updated according to the suggestion in that thread and also:

1. Made two test cases of the two test objectives previously stated as comments:
   * PSL attributes tests (1076-2019 16.2.7)
   * PSL API tests (1076-2019 16.5.8)
2. Configured VUnit to allow the testbench to have PSL errors without failing but at the same time fail if the VHDL assertions verifying the PSL functionality find errors (of severity failure)