### PR TITLE
Fix error in tb_generic_packages_on_entity entity instantiation

### DIFF
--- a/vhdl_2008/tb_generic_packages_on_entity.vhd
+++ b/vhdl_2008/tb_generic_packages_on_entity.vhd
@@ -69,7 +69,7 @@ end entity ;
 
 architecture tb of tb_generic_packages_on_entity is
 begin
-  U_test : entity test;
+  U_test : entity work.test;
   test_runner : process is
   begin
     test_runner_setup(runner, runner_cfg);
@@ -78,4 +78,3 @@ begin
     wait ;
   end process;
 end architecture;
-


### PR DESCRIPTION
The entity `test` isn't visible here so replace it with `work.test`. With this change this test can pass with the latest NVC master branch.