### PR TITLE
Improve tb_function_knows_return_vector_size case

### DIFF
--- a/vhdl_2019/tb_072b.vhd
+++ b/vhdl_2019/tb_072b.vhd
@@ -1,25 +1,26 @@
 -- LCS-2016-072b: Function knows return vector size
 -- http://www.eda-twiki.org/cgi-bin/view.cgi/P1076/LCS2016_072b
+library ieee ;
+use ieee.std_logic_1164.all ;
+
 package pack072b is
 
-    function resize(x : bit_vector) return rv_t of bit_vector ;
+    function resize(x : std_logic_vector) return rv_t of std_logic_vector ;
 
 end package ;
 
 package body pack072b is
 
-    function resize(x : bit_vector) return rv_t of bit_vector is
-        alias xa : bit_vector(x'high downto 0) is x ;
-        variable rv : rv_t ;
+    function resize(x : std_logic_vector) return rv_t of std_logic_vector is
+        alias xa : std_logic_vector(x'length - 1 downto 0) is x ;
+        variable rv : rv_t  := (others => '0') ;
+        alias ra : std_logic_vector(rv'length - 1 downto 0) is rv ;
     begin
-        if x'length > rv'length then
-            for idx in rv'range loop
-                rv(idx) := x(idx) ;
-            end loop ;
+        if rv'length < x'length then
+            ra(ra'left downto 0) := xa(ra'left downto 0) ;
         else
-            for idx in x'range loop
-                rv(idx) := x(idx) ;
-            end loop ;
+            ra(ra'left downto xa'left + 1) := (others => '0') ;
+            ra(xa'left downto 0) := x ;
         end if ;
         return rv ;
     end function ;
@@ -33,6 +34,9 @@ context vunit_lib.vunit_context;
 
 use work.pack072b.all ;
 
+library ieee;
+use ieee.std_logic_1164.all;
+
 entity tb_function_knows_return_vector_size is
   generic ( runner_cfg : string );
 end entity;
@@ -40,9 +44,19 @@ end entity;
 architecture tb of tb_function_knows_return_vector_size is
 begin
   test_runner: process is
+    variable v1 : std_logic_vector(1 to 3);
+    variable v2 : std_logic_vector(1 to 0);
   begin
     test_runner_setup(runner, runner_cfg);
     info("LCS-2016-072b: Function knows return vector size");
+
+    v1 := resize("1010101");
+    check_equal(v1, std_logic_vector'("101"));
+    v2 := resize("1111");
+    check_equal(v2, std_logic_vector'(1 to 0 => '0'));
+    v1 := resize("1");
+    check_equal(v1, std_logic_vector'("001"));
+
     test_runner_cleanup(runner);
     wait;
   end process test_runner;


### PR DESCRIPTION
At the moment this test doesn't actually call the resize function so an implementation can pass this test without fully implementing the feature.  Also the resize algorithm here doesn't seem to work correctly so I replaced it with a simpler one (using std_logic_vector as there is no check_equals overload for bit_vector).