### PR TITLE
Missing architecture for entity e071a in vhdl_2019/tb_071a.vhd

### DIFF
--- a/vhdl_2019/tb_071a.vhd
+++ b/vhdl_2019/tb_071a.vhd
@@ -1,11 +1,23 @@
 -- LCS-2016-071a: Extra optional semicolon at the end of interface_list
 -- http://www.eda-twiki.org/cgi-bin/view.cgi/P1076/LCS2016_071a
 entity e071a is
+  generic ( g : in natural ; ) ;
   port (
     a   :   in  bit ;
     b   :   out integer ;
   ) ;
 end entity ;
+
+architecture test of e071a is
+  component comp is
+    port ( x : in bit ; ) ;
+  end component;
+
+  procedure proc ( p : in integer ; ) is
+  begin
+  end procedure ;
+begin
+end architecture;
 
 --
 


### PR DESCRIPTION
There is no architecture for e071a so it cannot be instantiated:

```
** Fatal: no suitable architecture for VHDL_2019.E071A                                         
    > /home/nick/src/Compliance-Tests/vhdl_2019/tb_071a.vhd:23                                 
    |                                                                                          
 23 |   U_e071a : entity work.e071a                                                            
    |   ^                             
```

Added one plus test for trailing semicolon in a few more places.