### PR TITLE
Map missing generic to tb_071a.

### DIFF
--- a/vhdl_2019/tb_071a.vhd
+++ b/vhdl_2019/tb_071a.vhd
@@ -29,11 +29,14 @@ entity tb_extra_optional_semicolon_on_interface_list is
 end entity;
 
 architecture tb of tb_extra_optional_semicolon_on_interface_list is
+  constant g : natural := 10;
   signal a : bit ;
   signal b : integer ;
 begin
   U_e071a : entity work.e071a
-    port map (
+    generic map (
+      g => g
+    ) port map (
       a => a,
       b => b
     ) ;


### PR DESCRIPTION
Map a missing generic that was added to tb_071a.  Fixes #50.